### PR TITLE
Implemented latin character conversion using encoding

### DIFF
--- a/src/Statica/Statica.csproj
+++ b/src/Statica/Statica.csproj
@@ -27,8 +27,9 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Piranha" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Statica/Utils.cs
+++ b/src/Statica/Utils.cs
@@ -9,13 +9,20 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Statica
 {
     public static class Utils
     {
+        /// <summary>
+        /// Register provider for ISO-8859-8 encoding
+        /// </summary>
+        static Utils() => Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
         /// <summary>
         /// Generates a title for the given filesystem info.
         /// </summary>
@@ -44,22 +51,12 @@ namespace Statica
             // Trim & make lower case
             var slug = str.Trim().ToLower();
 
-            // Convert culture specific characters
-            slug = slug
-                .Replace("å", "a")
-                .Replace("ä", "a")
-                .Replace("á", "a")
-                .Replace("à", "a")
-                .Replace("ö", "o")
-                .Replace("ó", "o")
-                .Replace("ò", "o")
-                .Replace("é", "e")
-                .Replace("è", "e")
-                .Replace("í", "i")
-                .Replace("ì", "i");
+            // "Latinize" culture-specific characters
+            var tempBytes = Encoding.GetEncoding("ISO-8859-8").GetBytes(slug);
+            slug = Encoding.UTF8.GetString(tempBytes);
 
             // Remove special characters
-            slug = Regex.Replace(slug, @"[^a-z0-9-/ ]", "").Replace("--", "-");
+            slug = Regex.Replace(slug, @"[^a-z0-9-/ ]", "");
 
             // Remove whitespaces
             slug = Regex.Replace(slug.Replace("-", " "), @"\s+", " ").Replace(" ", "-");


### PR DESCRIPTION
Rather than maintaining a map of culture-specific characters to convert to "Latinized" equivalents, use ISO-8859-8 encoding, as described here.

https://stackoverflow.com/a/2086575/4028303